### PR TITLE
Add default configuration options

### DIFF
--- a/app/config/config.go
+++ b/app/config/config.go
@@ -64,11 +64,11 @@ var configOnce sync.Once
 var def = Default{
 	"localhost",
 	8443,
-	"etc/rmd/cert/server",
-	"etc/rmd/cert/client",
+	"/usr/local/etc/rmd/cert/server",
+	"/usr/local/etc/rmd/cert/client",
 	"challenge",
 	"",
-	"etc/rmd/policy.yaml",
+	"/usr/local/etc/rmd/policy.toml",
 }
 
 var db = Database{}

--- a/cmd/template/template.go
+++ b/cmd/template/template.go
@@ -19,7 +19,7 @@ var Options = map[string]interface{}{
 	"besteffort":      7,
 	"shared":          2,
 	"shrink":          false,
-	"policypath":      "/etc/rmd/policy.toml",
+	"policypath":      "/usr/local/etc/rmd/policy.toml",
 }
 
 // Templ is content of template
@@ -31,8 +31,8 @@ title = "RMD Config"
 address = "{{.address}}"
 policypath = "{{.policypath}}"
 tlsport = {{.tlsport}}
-# certpath = "/etc/rmd/cert/server" # Only support pem format, hard code that CAFile is ca.pem, CertFile is rmd-cert.pem, KeyFile is rmd-key.pem
-# clientcapath = "/etc/rmd/cert/client" # Only support pem format, hard code that CAFile is ca.pem
+# certpath = "/usr/local/etc/rmd/cert/server" # Only support pem format, hard code that CAFile is ca.pem, CertFile is rmd-cert.pem, KeyFile is rmd-key.pem
+# clientcapath = "/usr/local/etc/rmd/cert/client" # Only support pem format, hard code that CAFile is ca.pem
 clientauth = "{{.clientauth}}"  # can be "no, require, require_any, challenge_given, challenge", challenge means require and verify.
 # unixsock = "/var/run/rmd.sock"
 
@@ -45,7 +45,7 @@ stdout = {{.logtostdout}}
 [database]
 backend = "{{.dbbackend}}" # mgo
 transport = "{{.dbtransport}}" # mongodb://localhost
-dbname = "bolt" # RDTPolicy
+dbname = "bolt"
 
 [debug]
 enabled = false
@@ -69,12 +69,12 @@ besteffort = {{.besteffort}}
 shared = {{.shared}}
 
 [acl]
-path = "/etc/rmd/acl/"  #
+# path = "/usr/local/etc/rmd/acl/"  #
 # use CSV format
-filter = "url" # at present just support "url", will support "url,ip,proto"
+# filter = "url" # at present just support "url", will support "ip, proto"
 authorization = "signature" # authorize the client, can identify client by signature, role(OU) or username(CN). Default value is signature. If value is signature, admincert and usercert should be set.
-admincert = "/etc/rmd/acl/roles/admin/" # A cert is used to describe user info. These cert files in this path are used to define the users that are admin. Only pem format file at present. The files can be updated dynamicly.
-usercert = "/etc/rmd/acl/roles/user/" # A cert is used to describe user info. These cert files in this path are used to define the user with low privilege. Only pem format file at present. The files can be updated dynamicly.
+# admincert = "/usr/local/etc/rmd/acl/roles/admin/" # A cert is used to describe user info. These cert files in this path are used to define the users that are admin. Only pem format file at present. The files can be updated dynamicly.
+# usercert = "/usr/local/etc/rmd/acl/roles/user/" # A cert is used to describe user info. These cert files in this path are used to define the user with low privilege. Only pem format file at present. The files can be updated dynamicly.
 
 [pam]
 service = "rmd"

--- a/db/config/config.go
+++ b/db/config/config.go
@@ -14,8 +14,7 @@ type Database struct {
 
 var configOnce sync.Once
 
-// FIXME , the DBName should not be "bolt", "rmd" is more better.
-var db = &Database{"bolt", "var/run/rmd.db", "bolt"}
+var db = &Database{"bolt", "/var/run/rmd/rmd.db", "rmd"}
 
 // NewConfig is Concurrency safe.
 func NewConfig() Database {

--- a/etc/rmd/rmd.toml
+++ b/etc/rmd/rmd.toml
@@ -3,53 +3,53 @@
 title = "RMD config"
 
 [default]
-address = "localhost"
-policypath = "/etc/rmd/policy.toml"
-tlsport = 8443 # requires a port number higher than 1024
-# certpath = "etc/rmd/cert/server" # Only support pem format, hard code that CAFile is ca.pem, CertFile is rmd-cert.pem, KeyFile is rmd-key.pem
-# clientcapath = "etc/rmd/cert/client" # Only support pem format, hard code that CAFile is ca.pem
-clientauth = "challenge"  # can be "no, require, require_any, challenge_given, challenge", challenge means require and verify.
-# unixsock = "./var/run/rmd.sock"
+# address = "localhost"
+# policypath = "/user/local/etc/rmd/policy.toml"
+# tlsport = 8443 # requires a port number higher than 1024
+# certpath = "/usr/local/etc/rmd/cert/server" # Only support pem format, hard code that CAFile is ca.pem, CertFile is rmd-cert.pem, KeyFile is rmd-key.pem
+# clientcapath = "/usr/local/etc/rmd/cert/client" # Only support pem format, hard code that CAFile is ca.pem
+# clientauth = "challenge"  # can be "no, require, require_any, challenge_given, challenge", challenge means require and verify.
+# unixsock = "/var/run/rmd.sock"
 
 [debug]
-enabled = false
-debugport = 8081
+# enabled = false # allow rmd to run without any auth with http protocol
+# debugport = 8081
 
 [log]
-path = "/var/log/rmd.log"
-env = "dev"  # production or dev
-level = "debug"
-stdout = true
+# path = "/var/log/rmd/rmd.log"
+# env = "dev"  # production or dev
+# level = "debug"
+# stdout = true
 
 [database]
-backend = "bolt" # mgo
-transport = "/var/run/rmd.db" # mongodb://localhost
-dbname = "bolt" # RDTPolicy
+# backend = "bolt" # mgo
+# transport = "/var/run/rmd/rmd.db" # mongodb://localhost
+# dbname = "rmd"
 
 [OSGroup] # mandatory
-cacheways = 1
-cpuset = "0-1"
+# cacheways = 1
+# cpuset = "0"
 
 [InfraGroup] # optional
-cacheways = 19
-cpuset = "2-3"
+# cacheways = 19
+# cpuset = "2-3"
 # arrary or comma-separated values
-tasks = ["ovs*"] # just support Wildcards
+# tasks = ["ovs*"] # just support Wildcards
 
 [CachePool] # Cache Pool config is optional
-shrink = false # whether allow to shrink cache ways in best effort pool
-max_allowed_shared = 10 # max allowed workload in shared pool, default is 10
-guarantee = 10
-besteffort = 7
-shared = 2
+# shrink = false # whether allow to shrink cache ways in best effort pool
+# max_allowed_shared = 10 # max allowed workload in shared pool, default is 10
+# guarantee = 10
+# besteffort = 7
+# shared = 2
 
 [acl]
-path = "/etc/rmd/acl/"  #
+# path = "/usr/local/etc/rmd/acl/"#
 # use CSV format
-filter = "url" # at present just support "url", will support "url,ip,proto"
-authorization = "role" # authorize the client, can identify client by signature, role(OU) or username(CN). Default value is signature. If value is signature, admincert and usercert should be set.
-admincert = "/etc/rmd/acl/roles/admin/" # A cert is used to describe user info. These cert files in this path are used to define the users that are admin. Only pem format file at present. The files can be updated dynamically.
-usercert = "/etc/rmd/acl/roles/user/" # A cert is used to describe user info. These cert files in this path are used to define the user with low privilege. Only pem format file at present. The files can be updated dynamically.
+# filter = "url" # at present just support "url", will support "ip, proto"
+# authorization = "role" # authorize the client, can identify client by signature, role(OU) or username(CN). Default value is signature. If value is signature, admincert and usercert should be set.
+# admincert = "/usr/local/etc/rmd/acl/roles/admin/" # A cert is used to describe user info. These cert files in this path are used to define the users that are admin. Only pem format file at present. The files can be updated dynamically.
+# usercert = "/usr/local/etc/rmd/acl/roles/user/" # A cert is used to describe user info. These cert files in this path are used to define the user with low privilege. Only pem format file at present. The files can be updated dynamically
 
 [pam]
-service = "rmd"
+# service = "rmd"

--- a/lib/cpu/microarch.go
+++ b/lib/cpu/microarch.go
@@ -2,6 +2,8 @@ package cpu
 
 import (
 	"github.com/spf13/viper"
+
+	"fmt"
 	"sync"
 )
 
@@ -22,6 +24,11 @@ type microArch struct {
 }
 
 var cpumapOnce sync.Once
+var defaultConfigPath = []string{
+	"/usr/local/etc/rmd/",
+	"/etc/rmd/",
+	"./etc/rmd",
+}
 
 // NewCPUMap init internal cpu map
 // Concurrency safe.
@@ -30,16 +37,16 @@ func NewCPUMap() map[uint32]string {
 		var rtViper = viper.New()
 		var maps = map[string][]microArch{}
 
-		// supported extensions are "json", "toml", "yaml", "yml", "properties", "props", "prop"
 		rtViper.SetConfigType("toml")
-		rtViper.SetConfigName("cpu_map")    // no need to include file extension
-		rtViper.AddConfigPath("/etc/rmd/")  // path to look for the config file in
-		rtViper.AddConfigPath("$HOME/rmd")  // call multiple times to add many search paths
-		rtViper.AddConfigPath("./etc/rmd/") // set the path of your config file
+		rtViper.SetConfigName("cpu_map")
+		for _, p := range defaultConfigPath {
+			viper.AddConfigPath(p)
+		}
 		err := rtViper.ReadInConfig()
 
 		if err != nil {
-			panic("Failed to Read from CPU config")
+			// TODO using log
+			fmt.Printf("No cpu map found from %v, fall back to using default cpu map\n", defaultConfigPath)
 		}
 
 		rtViper.Unmarshal(&maps)

--- a/model/cache/cache.go
+++ b/model/cache/cache.go
@@ -219,13 +219,9 @@ func (c *Infos) GetByLevel(level uint32) *rmderror.AppError {
 			newCachdinfo.AvailableCPUs = cpuPools["all"][sc.ID].And(defaultCpus).ToHumanString()
 			newCachdinfo.AvailableIsoCPUs = cpuPools["isolated"][sc.ID].And(defaultCpus).ToHumanString()
 
-			p, err := policy.GetDefaultPlatformPolicy()
-			if err != nil {
-				return rmderror.NewAppError(http.StatusInternalServerError,
-					"Error to get policy", err)
-			}
+			p, _ := policy.GetDefaultPlatformPolicy()
+			// ignor policy error, p is an empty slice if policy file does not existed
 			ap := make(map[string]uint32)
-			//ap_counter := make(map[string]int)
 			for _, pv := range p {
 				// pv is policy.CATConfig.Catpolicy
 				for t := range pv {

--- a/model/policy/policy.go
+++ b/model/policy/policy.go
@@ -41,7 +41,7 @@ func LoadPolicy() (*CATConfig, error) {
 
 	if !strings.HasPrefix(configFileExt, ".") {
 		err := fmt.Errorf("Unknow policy file type extension %s", configFileExt)
-		log.Fatalf("error: %v", err)
+		log.Warnf("error: %v", err)
 		return nil, err
 	}
 
@@ -56,17 +56,16 @@ func LoadPolicy() (*CATConfig, error) {
 	r, err := ioutil.ReadFile(appconf.Def.PolicyPath)
 	if err != nil { // Handle errors reading the config file
 		err := fmt.Errorf("Fatal error config file: %s", err)
-		log.Fatalf("error: %v", err)
+		log.Warnf("error: %v", err)
 		return nil, err
 	}
 	runtimeViper := viper.New()
 	runtimeViper.SetConfigType(configType)
 	err = runtimeViper.ReadConfig(bytes.NewBuffer(r)) // Find and read the config file
-	if err != nil {                                   // Handle errors reading the config file
+	if err != nil {
 		err := fmt.Errorf("Fatal error config file: %s", err)
-		log.Fatalf("error: %v", err)
+		log.Warnf("error: %v", err)
 		return nil, err
-
 	}
 
 	c := CATConfig{}
@@ -115,10 +114,10 @@ func GetDefaultPlatformPolicy() ([]Policy, error) {
 func GetPolicy(cpu, policy string) (map[string]string, error) {
 	m := make(map[string]string)
 
-	platform, err := GetPlatformPolicy(cpu)
+	platform, err := GetPlatformPolicy(strings.ToLower(cpu))
 
 	if err != nil {
-		return m, fmt.Errorf("Can not find specified platform policy")
+		return m, fmt.Errorf("Can not find specified platform policy for %s", cpu)
 	}
 
 	var policyCandidate []Policy

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -3,7 +3,7 @@
 BASE=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 source $BASE/go-env
 
-cp -r $BASE/../etc/rmd /etc
+cp -r $BASE/../etc/rmd /usr/local/etc
 
 USER="rmd"
 useradd $USER || echo "User rmd already exists."
@@ -27,4 +27,4 @@ else
 fi
 
 DATA="\"logfile\":\"$LOGFILE\", \"dbtransport\":\"$DBFILE\", \"logtostdout\":false"
-go run $BASE/../cmd/gen_conf.go -path /etc/rmd/rmd.toml -data "{$DATA}"
+go run $BASE/../cmd/gen_conf.go -path /usr/local/etc/rmd/rmd.toml -data "{$DATA}"

--- a/util/acl/config/config.go
+++ b/util/acl/config/config.go
@@ -38,7 +38,7 @@ var authmap = map[string]Author{
 }
 
 var once sync.Once
-var acl = &ACL{"/etc/rmd/acl/", "url", "", "", Signature}
+var acl = &ACL{"/usr/local/etc/rmd/acl/", "url", "", "", Signature}
 
 // NewACLConfig create new ACL config
 func NewACLConfig() *ACL {

--- a/util/conf/conf.go
+++ b/util/conf/conf.go
@@ -8,6 +8,12 @@ import (
 	"github.com/spf13/viper"
 )
 
+var defaultConfigPath = []string{
+	"/usr/local/etc/rmd/",
+	"/etc/rmd/",
+	"./etc/rmd",
+}
+
 // Init does config initial
 func Init() error {
 	viper.SetConfigName("rmd") // no need to include file extension
@@ -16,15 +22,14 @@ func Init() error {
 	if confDir != "" {
 		viper.AddConfigPath(confDir)
 	}
-	viper.AddConfigPath("/etc/rmd/")  // path to look for the config file in
-	viper.AddConfigPath("$HOME/rmd")  // call multiple times to add many search paths
-	viper.AddConfigPath("./etc/rmd/") // set the path of your config file
+	for _, p := range defaultConfigPath {
+		viper.AddConfigPath(p)
+	}
 	err := viper.ReadInConfig()
 	if err != nil {
 		// NOTE (ShaoHe Feng): only can use fmt.Println, can not use log.
 		// For log is not init at this point.
-		fmt.Println(err)
-		return err
+		fmt.Printf("No config file found from %v, fall back to using default setting\n", defaultConfigPath)
 	}
 	return nil
 }

--- a/util/log/config/config.go
+++ b/util/log/config/config.go
@@ -18,7 +18,7 @@ type Log struct {
 }
 
 var configOnce sync.Once
-var log = &Log{"var/log/rmd.log", "dev", "debug", true}
+var log = &Log{"/var/log/rmd/rmd.log", "dev", "debug", true}
 
 // NewConfig loads log config
 func NewConfig() Log {

--- a/util/rdtpool/config/config.go
+++ b/util/rdtpool/config/config.go
@@ -14,7 +14,6 @@ type OSGroup struct {
 
 // InfraGroup represents infra group configuration
 type InfraGroup struct {
-	//OSGroup
 	CacheWays uint     `toml:"cacheways"`
 	CPUSet    string   `toml:"cpuset"`
 	Tasks     []string `toml:"tasks"`
@@ -35,7 +34,9 @@ var cachePoolConfigOnce sync.Once
 
 var infragroup = &InfraGroup{}
 var osgroup = &OSGroup{1, "0"}
-var cachepool = &CachePool{10, 0, 0, 0, false}
+
+// FIXME: the default may not work on some platform
+var cachepool = &CachePool{10, 10, 7, 2, false}
 
 // NewInfraConfig reads InfraGroup configuration
 func NewInfraConfig() *InfraGroup {


### PR DESCRIPTION
Add default configuration to RMD, so that even no configuration file
provided, RMD can still run without issue.

This is aimed for user quick start.

A user can directlly download RMD binary then just run './rmd --debug',
  by doing that, RMD will run in debug mode, no policy defined.

If user looks for furture feature support like TLS, ACL, they can then
turn for looking for the configuration sample file in etc/rmd.

This patch also changes the configure file search order as:
1. /usr/local/etc/rmd
2. /etc/rmd
3. ./etc/rmd