### PR TITLE
Add build version for RMD

### DIFF
--- a/rmd.go
+++ b/rmd.go
@@ -16,6 +16,8 @@ import (
 	"github.com/intel/rmd/util/log"
 	logconf "github.com/intel/rmd/util/log/config"
 	"github.com/intel/rmd/util/pidfile"
+	"github.com/intel/rmd/version"
+	"github.com/spf13/pflag"
 )
 
 var rmduser = "rmd"
@@ -24,6 +26,12 @@ func main() {
 	// use pipe pair to communicate between root and normal process
 	var in, out proxy.PipePair
 	flag.InitFlags()
+
+	if pflag.Lookup("version").Value.String() == "true" {
+		fmt.Printf("RMD version: %s (%s)\n", version.Info["version"], version.Info["revision"])
+		os.Exit(0)
+	}
+
 	if err := conf.Init(); err != nil {
 		fmt.Println("Init config failed:", err)
 		os.Exit(1)

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,8 +1,16 @@
 #!/usr/bin/env bash
 # build rmd
+
 BASE=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 source $BASE/go-env
 __proj_dir="$(dirname "$__dir")"
+__repo_path="github.com/intel/rmd"
+BUILD_DATE=${BUILD_DATE:-$( date +%Y%m%d-%H:%M:%S )}
+
+version=$( git describe --tags --dirty --abbrev=14 | sed -E 's/-([0-9]+)-g/.\1+/' )
+revision=$( git rev-parse --short HEAD 2> /dev/null || echo 'unknown' )
+branch=$( git rev-parse --abbrev-ref HEAD 2> /dev/null || echo 'unknown' )
+go_version=$( go version | sed -e 's/^[^0-9.]*\([0-9.]*\).*/\1/' )
 
 echo "git commit: $(git log --pretty=format:"%H" -1)"
 
@@ -18,4 +26,12 @@ fi
 
 mkdir -p "${build_path}"
 echo "building rmd for ${GOOS}/${GOARCH}"
-go build -o "${build_path}/rmd" . || exit 1
+
+ldflags="
+    -X ${__repo_path}/version.Version=${version}
+    -X ${__repo_path}/version.Revision=${revision}
+    -X ${__repo_path}/version.Branch=${branch}
+    -X ${__repo_path}/version.BuildDate=${BUILD_DATE}
+    -X ${__repo_path}/version.GoVersion=${go_version}"
+
+go build -i -v -ldflags "$ldflags" -o ${build_path}/rmd .  || exit 1

--- a/util/flag/flags.go
+++ b/util/flag/flags.go
@@ -48,6 +48,7 @@ func InitFlags() {
 	pflag.String("address", "localhost", "Listen address")
 	pflag.Int("tlsport", 8443, "TLS listen port")
 	pflag.BoolP("debug", "d", false, "Enable debug")
+	pflag.BoolP("version", "", false, "Print RMD version")
 	pflag.String("unixsock", "", "Unix sock file path")
 	pflag.Int("debugport", 8081, "Debug listen port")
 	pflag.String("conf-dir", "", "Directy of config file")

--- a/version/version.go
+++ b/version/version.go
@@ -1,0 +1,19 @@
+package version
+
+// Build information
+var (
+	Version   string
+	Revision  string
+	Branch    string
+	BuildDate string
+	GoVersion string
+)
+
+// Info provides the iterable version information.
+var Info = map[string]string{
+	"version":   Version,
+	"revision":  Revision,
+	"branch":    Branch,
+	"buildDate": BuildDate,
+	"goVersion": GoVersion,
+}


### PR DESCRIPTION
Add a version flag to RMD command line.

Add new package version, which defines some variable for version info,
they will be populated when build.
