### PR TITLE
Fix wrong link to developer guide in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ From a logical point of view, there are several components of RMD:
 
 From a physical point of view, RMD is composed of two processes -- the front-end and the back-end. The splitting of RMD into two processes is of security concerns. The front-end process which conducts most of the jobs runs as a normal user (least privilege). Whereas the back-end process runs as a privileged user because it has to do modifications to the resctrl file system. The back-end process is deliberately kept as small/simple as possible. Only add logic to the back-end when there is definitely a need to lift privilege. The front-end and back-end communicates via an anonymous pipe.
 
-For more information on the design and architecture, please refer to the [developers guide](docs/developers_guide.md)
+For more information on the design and architecture, please refer to the [developers guide](docs/DeveloperQuickStart.md)
 
 ## API Introduction ##
 Please refer to the [API documentation](docs/api/v1/swagger.yaml) for a comprehensive description of RMD APIs. This section provides the introduction and rationale of the API entry points.


### PR DESCRIPTION
Use the correct link "docs/DeveloperQuickStart.md" instead of
"docs/developers_guide.md".

Signed-off-by: Lin Yang <lin.a.yang@intel.com>