### PR TITLE
Fix: fix crash if infragroup options are omitted

### DIFF
--- a/util/rdtpool/infragroup.go
+++ b/util/rdtpool/infragroup.go
@@ -39,7 +39,7 @@ func GetInfraGroupReserve() (base.Reserved, error) {
 	var returnErr error
 	infraOnce.Do(func() {
 		conf := config.NewInfraConfig()
-		if conf == nil {
+		if conf == nil || conf.CacheWays == 0 {
 			return
 		}
 		infraCPUbm, err := base.CPUBitmaps([]string{conf.CPUSet})
@@ -102,7 +102,7 @@ func GetInfraGroupReserve() (base.Reserved, error) {
 // SetInfraGroup sets infra resource group based on configuration
 func SetInfraGroup() error {
 	conf := config.NewInfraConfig()
-	if conf == nil {
+	if conf == nil || conf.CacheWays == 0 {
 		return nil
 	}
 


### PR DESCRIPTION
Infragroup is optional, so in the configure file, this configure section
can be omitted or set.

It works if the section is omitted, but crash if it is set but the
configure options are omitted.

Previously:
This configuration will fail:

```
[InfraGroup] # optional
```