### PR TITLE
Add deb build script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 .idea/
 vendor/
 build/
+pkg-build/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,39 @@
+language: go
 sudo: required
+addons:
+    apt:
+        packages:
+            - fakeroot
+            - openssl
+            - libpam0g-dev
+            - db-util
+go:
+    - 1.8
+    - 1.9
+    - tip
+
+before_install:
+    - if [ "${JOB}" = "check" ]; then go get -v github.com/golang/lint/golint; fi
+
+script:
+    - 'if [ "${JOB}" = "docker" ]; then make docker; fi'
+    - 'if [ "${JOB}" = "deb" ]; then make deb; fi'
+    - 'if [ "${JOB}" = "rpm" ]; then make rpm; fi'
+    - 'if [ "${JOB}" = "check" ]; then make check; fi'
+
+env:
+    global:
+        - GOARCH=amd64
+    matrix:
+        - JOB=docker
+        - JOB=deb
+        - JOB=rpm
+        - JOB=check
+
+notifications:
+      email:
+          on_success: change
+          on_failure: always
 
 services:
         - docker
-
-script:
-        - docker build -t rmd .

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,10 @@
 OS = $(shell uname -s | tr '[:upper:]' '[:lower:]')
 ARCH = $(shell uname -m)
-.PHONY: deps check build test-unit test-func install clean
+VERSION = $(shell git describe --abbrev=0 --tags | grep -Eo '[0-9]{1,3}\.[0-9]{1,3}')
+
+go-bin-deb = $(GOPATH)/bin/go-bin-deb
+
+.PHONY: build check clean deb deps docker install rpm test-func test-unit
 
 default: deps build
 
@@ -14,9 +18,19 @@ test-func: deps
 	bash -c "./scripts/test.sh -f"
 build: deps
 	bash -c "./scripts/build.sh"
+deb: build
+ifeq (x86_64, $(ARCH))
+	@$(go-bin-deb) generate --arch amd64 --version $(VERSION)
+else
+	@$(go-bin-deb) generate --arch $(ARCH) --version $(VERSION)
+endif
+rpm: build
+	@echo "build rpm, todo ..."
 install: build
 	mkdir -p /usr/local/sbin
 	cp build/$(OS)/$(ARCH)/rmd /usr/local/sbin/
 	bash -c "./scripts/install.sh --skip-pam-userdb"
+docker:
+	@docker build -t rmd .
 clean:
-	rm -rf build
+	rm -rf build pkg-build

--- a/deb.json
+++ b/deb.json
@@ -1,0 +1,34 @@
+{
+  "name": "rmd",
+  "maintainer": "intel-rmd <intel-rmd@intel.com>",
+  "description": "Resource management daemon",
+  "homepage": "https://github.com/intel/rmd",
+  "files": [
+    {
+      "from": "build/linux/x86_64/!name!",
+      "to": "/usr/local/sbin/",
+      "base": "build/!arch!",
+      "fperm": "0755"
+    },
+    {
+      "from": "etc/**/**",
+      "to": "/usr/local"
+    }
+  ],
+  "copyrights": [
+    {
+      "files": "*",
+      "copyright": "2017 intel-rmd <intel-rmd@intel.com>",
+      "license": "GPL-2",
+      "file": "LICENSE"
+    }
+  ],
+  "pre-depends": [
+      "openssl",
+      "libpam0g-dev"
+  ],
+  "systemd-file": "deb/rmd.service",
+  "postinst-file": "deb/postinst.sh",
+  "postrm-file": "deb/postrm.sh",
+  "prerm-file": "deb/prerm.sh"
+}

--- a/deb/postinst.sh
+++ b/deb/postinst.sh
@@ -1,0 +1,28 @@
+#!/bin/sh -xe
+
+echo "Post install of rmd"
+
+# todo
+# create a soft link of rmd
+ln -s /usr/local/sbin/x86_64/rmd  /usr/local/sbin/rmd
+
+USER="rmd"
+useradd $USER || echo "User rmd already exists."
+
+LOGFILE="/var/log/rmd/rmd.log"
+if [ ! -d ${LOGFILE%/*} ]; then
+    mkdir -p ${LOGFILE%/*}
+    chown $USER:$USER ${LOGFILE%/*}
+fi
+
+DBFILE="/var/run/rmd/rmd.db"
+if [ ! -d ${DBFILE%/*} ]; then
+    mkdir -p ${DBFILE%/*}
+    chown $USER:$USER  ${DBFILE%/*}
+fi
+
+if [ -f "/lib/systemd/system/rmd.service" ]; then
+    systemctl daemon-reload
+    systemctl enable rmd.service
+    systemctl start rmd.service
+fi

--- a/deb/postrm.sh
+++ b/deb/postrm.sh
@@ -1,0 +1,3 @@
+#!/bin/sh -xe
+
+rm -rf /usr/local/sbin/rmd

--- a/deb/prerm.sh
+++ b/deb/prerm.sh
@@ -1,0 +1,6 @@
+#!/bin/sh -xe
+
+if [ -f "/lib/systemd/system/rmd.service" ]; then
+    systemctl stop rmd.service
+    systemctl disable rmd.service
+fi

--- a/deb/rmd.service
+++ b/deb/rmd.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=rmd
+
+[Service]
+User=root
+Group=root
+ExecStart=/usr/local/sbin/rmd
+
+[Install]
+WantedBy=multi-user.target

--- a/scripts/deps.sh
+++ b/scripts/deps.sh
@@ -4,3 +4,11 @@ BASE=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 . $BASE/go-env
 
 go get github.com/Masterminds/glide && glide install
+
+# Install go-bin-deb
+# mkdir -p $GOPATH/src/github.com/mh-cbon/go-bin-deb
+# cd $GOPATH/src/github.com/mh-cbon/go-bin-deb
+# git clone https://github.com/mh-cbon/go-bin-deb.git .
+# glide install
+# go install
+go get github.com/mh-cbon/go-bin-deb


### PR DESCRIPTION
    Issue #26: Add debian and docker build script

    Use go-bin-deb[1] to generate deb package and docker image.

    Use follow command line:
    $ make deb
    $ make docker

    This patch also changes the travis ci config file to do deb/rpm/docker build
    testing on gate.

    [1]: https://github.com/mh-cbon/go-bin-deb

    TODO: the build for rpm is not done yet.