### PR TITLE
Issue#28 Doc: Add build host request

### DIFF
--- a/docs/DeveloperQuickStart.md
+++ b/docs/DeveloperQuickStart.md
@@ -5,6 +5,8 @@
 Follow https://golang.org/doc/install to install golang.
 Make sure you have your $GOPATH, $PATH setup correctly
 
+*Note: only support build RMD on linux host(GOOS=Linux)*
+
 e.g.
 ```
 export GOPATH=$HOME/go


### PR DESCRIPTION
Request build host to be Linux.

RMD depends on resctrl , which is only supported on linux for now.