### PR TITLE
Rename lib/syscache module to its path name lib/cache

### DIFF
--- a/CONTRIBUTOR
+++ b/CONTRIBUTOR
@@ -4,3 +4,4 @@
 Feng, Shaohe <shaohe.feng@intel.com>
 Dakshina Ilangovan <dakshina.ilangovan@intel.com>
 Qiao, Liyong <liyong.qiao@intel.com>
+Lin, Yang <lin.a.yang@intel.com>

--- a/api/v1/caches.go
+++ b/api/v1/caches.go
@@ -9,7 +9,7 @@ import (
 	"github.com/emicklei/go-restful"
 	log "github.com/sirupsen/logrus"
 
-	"github.com/intel/rmd/lib/cache"
+	syscache "github.com/intel/rmd/lib/cache"
 	m_cache "github.com/intel/rmd/model/cache"
 )
 

--- a/lib/cache/cache.go
+++ b/lib/cache/cache.go
@@ -1,6 +1,6 @@
 // +build linux
 
-package syscache
+package cache
 
 import (
 	"io/ioutil"

--- a/model/cache/cache.go
+++ b/model/cache/cache.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 
 	rmderror "github.com/intel/rmd/api/error"
-	"github.com/intel/rmd/lib/cache"
+	syscache "github.com/intel/rmd/lib/cache"
 	"github.com/intel/rmd/lib/cpu"
 	"github.com/intel/rmd/lib/proc"
 	"github.com/intel/rmd/lib/resctrl"

--- a/model/hospitality/hospitality.go
+++ b/model/hospitality/hospitality.go
@@ -9,7 +9,7 @@ import (
 
 	rmderror "github.com/intel/rmd/api/error"
 	"github.com/intel/rmd/db"
-	libcache "github.com/intel/rmd/lib/cache"
+	syscache "github.com/intel/rmd/lib/cache"
 	"github.com/intel/rmd/lib/proxyclient"
 	"github.com/intel/rmd/model/policy"
 	"github.com/intel/rmd/util/rdtpool"
@@ -44,7 +44,7 @@ type Hospitality struct {
 
 // GetByRequest returns hospitality score by request
 func (h *Hospitality) GetByRequest(req *Request) error {
-	level := libcache.GetLLC()
+	level := syscache.GetLLC()
 	targetLev := strconv.FormatUint(uint64(level), 10)
 	cacheLevel := "l" + targetLev
 	cacheS := make(map[string]uint32)

--- a/model/workload/workload.go
+++ b/model/workload/workload.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 	"sync"
 
-	libcache "github.com/intel/rmd/lib/cache"
+	syscache "github.com/intel/rmd/lib/cache"
 	"github.com/intel/rmd/lib/cpu"
 	"github.com/intel/rmd/lib/proc"
 	"github.com/intel/rmd/lib/proxyclient"
@@ -66,7 +66,7 @@ func Enforce(w *tw.RDTWorkLoad) *rmderror.AppError {
 		return err
 	}
 
-	targetLev := strconv.FormatUint(uint64(libcache.GetLLC()), 10)
+	targetLev := strconv.FormatUint(uint64(syscache.GetLLC()), 10)
 	av, err := rdtpool.GetAvailableCacheSchemata(resaall, []string{"infra", "."}, er.Type, "L"+targetLev)
 	if err != nil {
 		return rmderror.NewAppError(http.StatusInternalServerError,
@@ -398,7 +398,7 @@ func populateEnforceRequest(req *tw.EnforceRequest, w *tw.RDTWorkLoad) *rmderror
 	}
 
 	cacheinfo := &cache.Infos{}
-	cacheinfo.GetByLevel(libcache.GetLLC())
+	cacheinfo.GetByLevel(syscache.GetLLC())
 
 	cpunum := cpu.HostCPUNum()
 	if cpunum == 0 {
@@ -482,7 +482,7 @@ func shrinkBEPool(resaall map[string]*resctrl.ResAssociation,
 	dbc, _ := db.NewDB()
 	// do a copy
 	availableSchemata := &(*reservedSchemata)
-	targetLev := strconv.FormatUint(uint64(libcache.GetLLC()), 10)
+	targetLev := strconv.FormatUint(uint64(syscache.GetLLC()), 10)
 	for name, v := range resaall {
 		if strings.HasSuffix(name, "-"+rdtpool.Besteffort) {
 			besteffortRes[name] = v

--- a/test/integration/caches_test.go
+++ b/test/integration/caches_test.go
@@ -10,7 +10,7 @@ import (
 
 	"gopkg.in/gavv/httpexpect.v1"
 
-	"github.com/intel/rmd/lib/cache"
+	syscache "github.com/intel/rmd/lib/cache"
 	"github.com/intel/rmd/test/test_helpers"
 )
 

--- a/util/rdtpool/base/base.go
+++ b/util/rdtpool/base/base.go
@@ -5,7 +5,7 @@ import (
 	"strconv"
 	"sync"
 
-	"github.com/intel/rmd/lib/cache"
+	syscache "github.com/intel/rmd/lib/cache"
 	"github.com/intel/rmd/lib/cpu"
 	"github.com/intel/rmd/lib/proxyclient"
 	"github.com/intel/rmd/lib/util"

--- a/util/rdtpool/cachepool.go
+++ b/util/rdtpool/cachepool.go
@@ -5,7 +5,7 @@ import (
 	"strconv"
 	"sync"
 
-	"github.com/intel/rmd/lib/cache"
+	syscache "github.com/intel/rmd/lib/cache"
 	util "github.com/intel/rmd/lib/util"
 	"github.com/intel/rmd/util/rdtpool/base"
 	"github.com/intel/rmd/util/rdtpool/config"

--- a/util/rdtpool/cpupool.go
+++ b/util/rdtpool/cpupool.go
@@ -3,7 +3,7 @@ package rdtpool
 import (
 	"sync"
 
-	"github.com/intel/rmd/lib/cache"
+	syscache "github.com/intel/rmd/lib/cache"
 	"github.com/intel/rmd/lib/cpu"
 	util "github.com/intel/rmd/lib/util"
 	"github.com/intel/rmd/util/rdtpool/base"

--- a/util/rdtpool/infragroup.go
+++ b/util/rdtpool/infragroup.go
@@ -3,15 +3,15 @@ package rdtpool
 import (
 	"fmt"
 	"github.com/gobwas/glob"
-	"github.com/intel/rmd/lib/cache"
-	"github.com/intel/rmd/lib/proc"
-	"github.com/intel/rmd/lib/resctrl"
 	log "github.com/sirupsen/logrus"
 	"strconv"
 	"strings"
 	"sync"
 
+	syscache "github.com/intel/rmd/lib/cache"
+	"github.com/intel/rmd/lib/proc"
 	"github.com/intel/rmd/lib/proxyclient"
+	"github.com/intel/rmd/lib/resctrl"
 	util "github.com/intel/rmd/lib/util"
 	"github.com/intel/rmd/util/rdtpool/base"
 	"github.com/intel/rmd/util/rdtpool/config"

--- a/util/rdtpool/osgroup.go
+++ b/util/rdtpool/osgroup.go
@@ -5,7 +5,7 @@ import (
 	"strconv"
 	"sync"
 
-	"github.com/intel/rmd/lib/cache"
+	syscache "github.com/intel/rmd/lib/cache"
 	"github.com/intel/rmd/lib/proxyclient"
 	util "github.com/intel/rmd/lib/util"
 	"github.com/intel/rmd/util/rdtpool/base"


### PR DESCRIPTION
Previously, the lib/cache path contains "syscache" module with a different
name. It is confusing when import lib/cache path, but directly use the syscache
module. So rename module name to "cache", which is consistent with its located
path name.