### PR TITLE
New API: /cachepool

### DIFF
--- a/api/v1/cachepool.go
+++ b/api/v1/cachepool.go
@@ -1,0 +1,36 @@
+package v1
+
+import (
+	"github.com/emicklei/go-restful"
+	"github.com/intel/rmd/util/rdtpool/config"
+)
+
+// CachePoolResource represents CachePool API resource
+type CachePoolResource struct {
+}
+
+// Register handlers
+func (c CachePoolResource) Register(container *restful.Container) {
+	ws := new(restful.WebService)
+	ws.
+		Path("/v1/cachepool").
+		Doc("Show the cachepool defined on the host").
+		Consumes(restful.MIME_JSON).
+		Produces(restful.MIME_JSON)
+
+	ws.Route(ws.GET("/").To(c.CacheGet).
+		Doc("Get the cachepool on the host").
+		Operation("CacheGet"))
+
+	container.Add(ws)
+}
+
+// CacheGet is handler to for GET
+func (c CachePoolResource) CacheGet(request *restful.Request, response *restful.Response) {
+	poolConf := config.NewCachePoolConfig()
+	cpSettings := make(map[string]uint)
+	cpSettings["guarantee"] = poolConf.Guarantee
+	cpSettings["besteffort"] = poolConf.Besteffort
+	cpSettings["shared"] = poolConf.Shared
+	response.WriteEntity(cpSettings)
+}

--- a/app/server.go
+++ b/app/server.go
@@ -111,6 +111,7 @@ func Initialize(c *Config) (*restful.Container, error) {
 	hospitality := v1.HospitalityResource{}
 	wls := v1.WorkLoadResource{Db: db}
 	mba := v1.MbaResource{}
+	cachepool := v1.CachePoolResource{}
 
 	// Register controller to container
 	caches.Register(wsContainer)
@@ -118,6 +119,7 @@ func Initialize(c *Config) (*restful.Container, error) {
 	hospitality.Register(wsContainer)
 	wls.Register(wsContainer)
 	mba.Register(wsContainer)
+	cachepool.Register(wsContainer)
 
 	// Install adds the SgaggerUI webservices
 	c.Swagger.WebServices = wsContainer.RegisteredWebServices()


### PR DESCRIPTION
Reports the maximum capability about the cache.
It just like the settings of configuration file.

Path:
/cachepool [GET]

Response example:
{
  "besteffort": 3,
  "guarantee": 6,
  "shared": 1
}