### PR TITLE
Correct typo/spelling errors in API Swagger YAML

### DIFF
--- a/docs/api/v1/swagger.yaml
+++ b/docs/api/v1/swagger.yaml
@@ -20,7 +20,7 @@ paths:
      get:
       summary: Host cache information
       description: |
-        Get the cache information, include level 2, level 3 cache information if has
+        Get the cache information, include level 2, level 3 cache information it has
       tags:
         - cache
       responses:
@@ -35,7 +35,7 @@ paths:
     get:
       summary: Host cache topology for specific level
       description: |
-        Get the cache infor for specified cache level, also the endpoint suppport provide llc
+        Get the cache information for specified cache level, also the endpoint suppport provide llc
       tags:
         - cache
       parameters:
@@ -47,7 +47,7 @@ paths:
         enum: ['l3', 'l2', 'llc']
       responses:
         200:
-          description: An array cache infor
+          description: An array cache information
           schema:
             type: array
             items:
@@ -176,7 +176,7 @@ paths:
     get:
       summary: List pre-defined cache policy
       description: |
-        List pre-defined cache polies
+        List pre-defined cache policies
       tags:
         - policy
       responses:
@@ -206,10 +206,10 @@ definitions:
         description: rdt supported
       cqm:
         type: boolean
-        description: cache mointoring suppported
+        description: cache quality monitoring supported
       cdp:
         type: boolean
-        description: cache mointoring suppported
+        description: code data prioritization supported
       caches:
         $ref: '#/definitions/CacheSummary'
   CacheInfo:
@@ -223,14 +223,14 @@ definitions:
         description: total size of the cache
       cdp:
         type: boolean
-        description: cache mointoring suppported
+        description: code data prioritization supported
   CacheInfos:
     type: object
     properties:
       number:
         type: integer
         format: int32
-        description: number of cache infor
+        description: number of cache information
       Caches:
         $ref: '#/definitions/CacheInfo'
   Workload:


### PR DESCRIPTION
A few things I didn't change but which should be made clearer:

- Task list/task ID. Line 72 says a workload can be created by providing a task list, but it is not included in the example and it is not clear to me where the user would obtains these. This isn't a reference to Linux process IDs is it?
- The use of CacheSummary and CachesSummary as two different kinds of object is confusing. Some additional explanation would be a good idea.
- Lines 254, 257 and 260 all have identical descriptions. Is that correct? My guess is that 254 is the requested priority, 257 is the actual priority (which I'm guessing might not match the requested) and 260 I'm guessing that cos (on line 259) is Class Of Service but I don't know how that relates to workload priority tier.
- The term hospitality needs a better explanation both here an in https://github.com/intel/rmd/blob/master/docs/UserGuide.md because it is not at all clear what it actually means. Is it correct that it's a POST only API? There's no GET section for it in swagger.yaml. It kind of looks to me like this might be a "dry run" version of the workload API, asking "if I posted a workload with this max/min, would it succeed or fail" but that's just a guess because the docs are very unclear about it.